### PR TITLE
Fixed addAsPriority

### DIFF
--- a/src/store/ItemsProvider.jsx
+++ b/src/store/ItemsProvider.jsx
@@ -10,7 +10,7 @@ const ItemsProvider = ({ children }) => {
     //Add our functionality (Use Reducer for more complex functionality)
     const addAsToDo = (item) => setToDoList([...toDoList, item]);
     const addAsDone = (item) => setDoneList([...doneList, item]);
-    const addAsPriority = (item) => setToDoList([item, ...toDoList]);
+    const addAsPriority = (item) => setToDoList([toDoList[0], item, ...toDoList.slice(1)]);
     const updateToDo = (item) => setToDoList(toDoList.map((i) => i.id === item.id ? { ...item } : i));
     const removeToDo = (id) => setToDoList(toDoList.filter((i) => i.id !== id));
 


### PR DESCRIPTION
Prior, the addAsPriority didn't work because it added the to-do as the very first element in the array.
That very first element was being used to display all the information in regards to the currentTask, in the Timer component.

One of the ideas was to pop the current Task from the list, so we could truly add to-dos as prioritys in the 0 index of the array, however, it was determined that popping the currentTask would come with many implications, and would require additional work.

It was decided to simply change the addAsPriority method in the ItemsProvider to add the item in the 1 index. Ensuring we don't run into any issues.