### PR TITLE
Refactored useTimer and clean-up timerUtils

### DIFF
--- a/src/hooks/useTimer.jsx
+++ b/src/hooks/useTimer.jsx
@@ -1,58 +1,41 @@
-import { getSecondsLeft, getPercentageLeft, getSecondsSinceStart } from "../utils/timerUtils";
+import { getSecondsLeft, getPercentageLeft } from "../utils/timerUtils";
 import { useState, useEffect } from "react";
 import { add } from "date-fns";
 
-const useTimer = () => {
-    //Update endTime with 'ExpectedEndTime'
-    const [data, setData] = useState({ startTime: null, endTime: null });
+export default function useTimer() {
+    const [timerData, setTimerData] = useState({ startTime: null, endTime: null });
+    const [currentTime, setCurrentTime] = useState(new Date());
     const [isRunning, setIsRunning] = useState(false);
-    //Remove this state with const [endTime, setEndTime] = useState(new Date());
-    const [seconds, setSeconds] = useState(0);
 
     const start = (avgMinutes = 60) => {
-        setData({
-            startTime: new Date(),
-            endTime: add(new Date(), { minutes: avgMinutes }),
-        });
+        const now = new Date();
+        setTimerData({ startTime: now, endTime: add(now, { minutes: avgMinutes }) });
+        setCurrentTime(now);
         setIsRunning(true);
     };
 
     const stop = () => {
-        setData({ startTime: null, endTime: null });
-        setSeconds(0);
+        setTimerData({ startTime: null, endTime: null });
         setIsRunning(false);
     }
 
-    //This will set endTime to new Date() every second.
     useEffect(() => {
         if (!isRunning) return;
-        const timer = setInterval(() => {
-            setSeconds(prev => prev + 1);
-        }, 1000);
-
+        const timer = setInterval(() => { setCurrentTime(new Date()) }, 1000);
         return () => clearInterval(timer);
     }, [isRunning]);
 
     return {
         timer: {
-            startTime: data.startTime,
-            endTime: new Date(),
-            //If we follow the commens at the end of the file, here we can do 
-            //date-fns.differenceInSeconds(data.startTime, data.endTime)
-            duration: getSecondsSinceStart(data.startTime),
+            startTime: timerData.startTime,
+            endTime: currentTime,
+            duration: getSecondsLeft(currentTime, timerData.startTime),
             isRunning,
-            secondsLeft: data.endTime ? getSecondsLeft(data.endTime) : 0,
-            percentage: data.endTime ? getPercentageLeft(data.startTime, data.endTime) : 0,
+            onTime: timerData.endTime ? timerData.endTime > currentTime : false,
+            secondsLeft: timerData.endTime ? getSecondsLeft(timerData.endTime, currentTime) : 0,
+            percentage: timerData.endTime ? getPercentageLeft(timerData.startTime, timerData.endTime, currentTime) : 0,
         },
         start,
         stop,
     };
-};
-
-export default useTimer;
-
-/* 
-Can we make it so instead of increasing a second every second, we simply update data.endTime = new Date()?
-That way we removed the variable we are NOT using.
-And we don't have to create so many new Date() objects in our timeUtils.js file.
-*/
+}

--- a/src/utils/timerUtils.js
+++ b/src/utils/timerUtils.js
@@ -5,21 +5,14 @@ const padNumber = number => number.toString().padStart(2, '0');
 
 export const secondsToMinutes = (seconds) => Math.floor(seconds / 60);
 
-export const getSecondsLeft = (end) => {
-    const now = new Date();
-    const msDifference = end - now;
-    return Math.floor(msDifference / 1000);
+export const getSecondsLeft = (endTime, currentTime) =>
+    Math.floor((endTime - currentTime) / 1000);
+
+export function secondsToTime(seconds) {
+    const timeString = formatSeconds(Math.abs(seconds));
+    return `${determineSign(seconds, 0)}${timeString}`;
 }
 
-export const getSecondsSinceStart = (start) => {
-    if (start === null) return 0;
-    const now = new Date();
-    const milliseconds = now.getTime() - start.getTime();
-    return Math.round(milliseconds / 1000);
-}
-
-
-// Assume `now` and `end` are Date objects
 export function getTimeLeft(end) {
     const now = new Date();
     const msDifference = Math.abs(end - now);
@@ -27,29 +20,15 @@ export function getTimeLeft(end) {
     return `${determineSign(end, now)}${timeString}`;
 }
 
-export function secondsToTime(seconds) {
-    const timeString = formatSeconds(Math.abs(seconds));
-    return `${determineSign(seconds, 0)}${timeString}`;
+export function getPercentageLeft(startTime, endTime, currentTime) {
+    if (currentTime > endTime) return 0;
+
+    const totalMili = Math.abs(endTime - startTime);
+    const miliLeft = Math.abs(endTime - currentTime);
+    return Math.round((miliLeft / totalMili) * 100);
 }
 
-export function getPercentageLeft(startTime, endTime) {
-    const now = new Date();
-    if (now > endTime)
-        return 0;
-
-    const totalMs = Math.abs(endTime - startTime);
-    const msLeft = Math.abs(endTime - now);
-    return Math.round((msLeft / totalMs) * 100);
-}
-
-export function minutesToTime(minutes) {
-    const hours = Math.floor(minutes / 60);
-    const minutesLeft = minutes % 60;
-
-    return `${padNumber(hours)}:${padNumber(minutesLeft)}:00`;
-}
-
-export function formatSeconds(seconds) {
+function formatSeconds(seconds) {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor(seconds / 60);
     const secondsLeft = seconds % 60;
@@ -57,7 +36,7 @@ export function formatSeconds(seconds) {
     return `${padNumber(hours)}:${padNumber(minutes)}:${padNumber(secondsLeft)}`;
 }
 
-export const msToTime = (miliseconds) => {
+const msToTime = (miliseconds) => {
     // Calculate hours, minutes and seconds
     const hours = Math.floor(miliseconds / 3600000);
     const minutes = Math.floor(miliseconds / 60000);


### PR DESCRIPTION
Refactored useTimer to stop using seconds, setSeconds. Instead made it update 'currentTime' which is a Date Object.
This better conveys the purpose of the hook and reduces significantly the number of new Date() object we must create both in useTimer and timerUtils.