### PR TITLE
Fixed bug in formatSeconds function

### DIFF
--- a/src/utils/timerUtils.js
+++ b/src/utils/timerUtils.js
@@ -30,9 +30,8 @@ export function getPercentageLeft(startTime, endTime, currentTime) {
 
 function formatSeconds(seconds) {
     const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor(seconds / 60);
+    const minutes = Math.floor((seconds % 3600) / 60);
     const secondsLeft = seconds % 60;
-
     return `${padNumber(hours)}:${padNumber(minutes)}:${padNumber(secondsLeft)}`;
 }
 


### PR DESCRIPTION
Bug caused Timer to display times like:

01:60:00
01:120:00

Now we are using remainder % operator to substract the seconds used in hours to later calculate minutes.
Seconds is not being affected by this. 